### PR TITLE
[feat] : 족보페이지 접근 권한 설정 (#2)

### DIFF
--- a/src/main/java/com/example/tuxBack/config/SecurityConfig.java
+++ b/src/main/java/com/example/tuxBack/config/SecurityConfig.java
@@ -13,20 +13,27 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    // 일단은 로그인하지 않더라도 모든 페이지에 접근할 수 있게 설정.
-   @Bean
-   SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
-       http.csrf().disable();
-       http.authorizeHttpRequests().requestMatchers(
-               new AntPathRequestMatcher("/**")
-       ).permitAll();
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http.csrf().disable();
+        // 일단은 로그인하지 않더라도 모든 페이지에 접근할 수 있게 설정.
+//        http.authorizeHttpRequests().requestMatchers(
+//                new AntPathRequestMatcher("/**")
+//        ).permitAll();
 
-       return http.build();
-   }
+        //우선적으로, 족보 페이지만 접근 통제 설정.
+       http
+               .authorizeHttpRequests((authz) -> authz
+                       .requestMatchers("/exam").hasRole("USER")
+                       .anyRequest().permitAll()
+               );
 
-   @Bean
+        return http.build();
+    }
+
+    @Bean
     PasswordEncoder passwordEncoder(){
-       return new BCryptPasswordEncoder();
-   }
+        return new BCryptPasswordEncoder();
+    }
 
 }


### PR DESCRIPTION
## 개요
족보 페이지(/exam)에 접근하는 사용자의 권한을 통제하도록 spring security 설정 함.

## 추가 사항
현재 다른 페이지들에도 접근 권한 설정이 필요함.
또한 실제로 USER권한을 가지면 접근이 가능한 지 확인이 필요함. 
service를 통해 사용자가 /exam경로에 접근하면 백에서 access가능한지에 대한 답을 줘야하는데 어떤게 프론트와 백을 연결하지 고민해야 함.